### PR TITLE
Linked list-based growing Arena

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.vscode/
+.vs/
+build/
+*.out

--- a/base.h
+++ b/base.h
@@ -628,11 +628,11 @@ void WaitTime(i64 ms) {
 void __ArenaNextChunk(Arena *arena, size_t bytes) {
   __ArenaChunk* next = arena->current ? arena->current->next : NULL;
   while(next) {
-    if (next->cap > bytes) {
-      arena->current = next;
+    arena->current = next;
+    if (arena->current->cap > bytes) {
       return;
     }
-    next = next->next;
+    next = arena->current->next;
   }
   next = (__ArenaChunk*)Malloc(sizeof(__ArenaChunk) + bytes);
   next->cap = bytes;
@@ -668,8 +668,9 @@ void *ArenaAlloc(Arena *arena, const size_t size) {
 void ArenaFree(Arena *arena) {
   __ArenaChunk* chunk = arena->root;
   while(chunk) {
+    __ArenaChunk* next = chunk->next;
     free(chunk);
-    chunk = chunk->next;
+    chunk = next;
   }
   free(arena);
 }

--- a/base_test.c
+++ b/base_test.c
@@ -1,0 +1,40 @@
+#define BASE_IMPLEMENTATION
+#include "base.h"
+
+static void TestVectors() {
+    StringVector vec = {0};
+    VecForEach(vec, str) {
+        LogError("Should not happen!");
+        exit(1);
+    }
+    VecPush(vec, S("1"));
+    VecPush(vec, S("2"));
+    VecPush(vec, S("3"));
+    VecForEach(vec, str) {
+        LogInfo("%s", str->data);
+    }
+    VecFree(vec);
+}
+
+static void TestArenas() {
+    Arena* a = ArenaCreate(1024);
+    uintptr_t ptr1 = (uintptr_t)ArenaAlloc(a, 1);
+    uintptr_t ptr2 = (uintptr_t)ArenaAlloc(a, 1);
+    if (ptr2 - ptr1 != DEFAULT_ALIGNMENT) {
+        LogError("Arena alignment fail");
+        exit(1);
+    }
+    uintptr_t ptr3 = (uintptr_t)ArenaAllocChars(a, 2);
+    if (ptr3 - ptr2 != 1) {
+        LogError("Arena char alignment fail");
+        exit(1);
+    }
+    ArenaAllocChars(a, 4000);
+    ArenaFree(a);
+}
+
+int main() {
+    TestVectors();
+    TestArenas();
+    LogInfo("Tests passed!");
+}


### PR DESCRIPTION
This _is_ an API break. But it should be better, no more need to do ArenaInit()

* Arena now grows with relocation
* Can specify alignment (to not waste a ton of memory on char* overalignment)

Arena grows using linked lists, so old pointers are still valid. On Reset() it reuses all previously allocated chunks. Chunk metadata is efficiently located just before buffer.

## Bonus:
* VecForEach
* Compatability with C++
* Very basic test-suite
* Attributes to help compiler see, that ArenaAlloc behaves just like malloc() and aligned_malloc()
