### PR TITLE
Fix bug in StrTrim and some copy-pasted errors

### DIFF
--- a/base.h
+++ b/base.h
@@ -1117,30 +1117,26 @@ void StrTrim(String *str) {
     return;
   }
 
-  char *first_char = NULL;
-  char *last_char = NULL;
-  for (size_t i = 0; i < str->length; ++i) {
-    char *curr_char = &str->data[i];
-    if (is_space(*curr_char)) {
-      continue;
-    }
-
-    if (first_char == NULL) {
-      first_char = curr_char;
-    } else {
-      last_char = curr_char;
-    }
+  size_t start = 0;
+  while (start < str->length && is_space(str->data[start])) {
+    start++;
   }
 
-  if (first_char == NULL || last_char == NULL) {
-    str->data[0] = '\0';
-    str->length = 0;
+  if (start == str->length) {
     add_null_terminator(str->data, 0);
+    str->length = 0;
     return;
   }
 
-  str->length = (last_char - first_char) + 1;
-  memmove(str->data, first_char, str->length);
+  size_t end = str->length - 1;
+  while (end > start && is_space(str->data[end])) {
+    end--;
+  }
+
+  str->length = end - start + 1;
+  if (start > 0) {
+    memmove(str->data, &str->data[start], str->length);
+  }
   add_null_terminator(str->data, str->length);
 }
 

--- a/base.h
+++ b/base.h
@@ -425,7 +425,7 @@ void logErrorV(const char *format, va_list args) FORMAT_CHECK(1, 0);
     a ^= b;        \
     b ^= a;        \
     a ^= b;        \
-  } while (0);
+  } while (0)
 
 /* --- Defer Macros --- */
 #if defined(DEFER_MACRO)
@@ -659,7 +659,7 @@ bool isUnix(void) {
 }
 
 bool isAndroid(void) {
-#  if defined(PLATFORM_EMSCRIPTEN)
+#  if defined(PLATFORM_ANDROID)
   return true;
 #  else
   return false;
@@ -1931,7 +1931,7 @@ int32_t IniGetInt(IniFile *ini_file, String key) {
   char *end_ptr;
   int32_t result = (int32_t)strtol(value.data, &end_ptr, 10);
   if (end_ptr == value.data) {
-    LogWarn("IniGetLong: Failed to convert [key: %s, value: %s] to int", key.data, value.data);
+    LogWarn("IniGetInt: Failed to convert [key: %s, value: %s] to int", key.data, value.data);
     return 0;
   }
 
@@ -1963,7 +1963,7 @@ float64_t IniGetDouble(IniFile *ini_file, String key) {
   char *end_ptr;
   float64_t result = strtod(value.data, &end_ptr);
   if (end_ptr == value.data) {
-    LogWarn("IniGetLong: Failed to convert [key: %s, value: %s] to double", key.data, value.data);
+    LogWarn("IniGetDouble: Failed to convert [key: %s, value: %s] to double", key.data, value.data);
     return 0.0;
   }
 


### PR DESCRIPTION
I'm an active user of `mate.h`, so thank you for your tools. I fixed a few errors in the code:

- `isAndroid():` was checking PLATFORM_EMSCRIPTEN instead of PLATFORM_ANDROID
- `StrTrim():` single char like `"  A  "` became just `""`. Rewrote it using a two-pointer (start/end) approach
- `Swap macro:` had a trailing `;` inside the `do { ... } while (0)` definition
- `IniGetInt / IniGetDouble:` warning messages had a copy-pasted `"IniGetLong"`

Also update `base.h` in the `mate.h` repo.